### PR TITLE
Fix #1

### DIFF
--- a/modeling/data.py
+++ b/modeling/data.py
@@ -8,14 +8,15 @@ NOTE: Some code taken directly from their documentation. See: https://financialm
 from urllib.request import urlopen
 import json
 
+APIKEY = ""
 
 def get_api_url(requested_data, ticker, period):
     if period == 'annual':
-        url = 'https://financialmodelingprep.com/api/v3/{requested_data}/{ticker}'.format(
-            requested_data=requested_data, ticker=ticker)
+        url = 'https://financialmodelingprep.com/api/v3/{requested_data}/{ticker}?apikey={apikey}'.format(
+            requested_data=requested_data, ticker=ticker, apikey=APIKEY)
     elif period == 'quarter':
-        url = 'https://financialmodelingprep.com/api/v3/{requested_data}/{ticker}?period=quarter'.format(
-            requested_data=requested_data, ticker=ticker)
+        url = 'https://financialmodelingprep.com/api/v3/{requested_data}/{ticker}?period=quarter&apikey={apikey}'.format(
+            requested_data=requested_data, ticker=ticker, apikey=APIKEY)
     else:
         raise ValueError("invalid period " + str(period))
     return url
@@ -105,8 +106,8 @@ def get_stock_price(ticker):
     returns:
         {'symbol': ticker, 'price': price}
     """
-    url = 'https://financialmodelingprep.com/api/v3/stock/real-time-price/{}'.format(
-        ticker)
+    url = 'https://financialmodelingprep.com/api/v3/stock/real-time-price/{ticker}?apikey={apikey}'.format(
+        ticker=ticker, apikey=APIKEY)
     return get_jsonparsed_data(url)
 
 
@@ -141,8 +142,8 @@ def get_historical_share_prices(ticker, dates):
     prices = {}
     for date in dates:
         date_start, date_end = date[0:8] + str(int(date[8:]) - 2), date
-        url = 'https://financialmodelingprep.com/api/v3/historical-price-full/{}?from={}&to={}'.format(
-            ticker, date_start, date_end)
+        url = 'https://financialmodelingprep.com/api/v3/historical-price-full/{ticker}?from={date_start}&to={date_end}&apikey={apikey}'.format(
+            ticker=ticker, date_start=date_start, date_end=date_end, apikey=APIKEY)
         try:
             prices[date_end] = get_jsonparsed_data(url)['historical'][0]['close']
         except IndexError:

--- a/modeling/data.py
+++ b/modeling/data.py
@@ -34,7 +34,11 @@ def get_jsonparsed_data(url):
     """
     response = urlopen(url)
     data = response.read().decode('utf-8')
-    return json.loads(data)
+    json_data = json.loads(data)
+    if "Error Message" in json_data:
+        raise ValueError("Error while requesting data from '{url}'. Error Message: '{err_msg}'.".format(
+            url=url, err_msg=json_data["Error Message"]))
+    return json_data
 
 
 def get_EV_statement(ticker, period='annual'):

--- a/modeling/data.py
+++ b/modeling/data.py
@@ -9,6 +9,18 @@ from urllib.request import urlopen
 import json
 
 
+def get_api_url(requested_data, ticker, period):
+    if period == 'annual':
+        url = 'https://financialmodelingprep.com/api/v3/{requested_data}/{ticker}'.format(
+            requested_data=requested_data, ticker=ticker)
+    elif period == 'quarter':
+        url = 'https://financialmodelingprep.com/api/v3/{requested_data}/{ticker}?period=quarter'.format(
+            requested_data=requested_data, ticker=ticker)
+    else:
+        raise ValueError("invalid period " + str(period))
+    return url
+
+
 def get_jsonparsed_data(url):
     """
     Fetch url, return parsed json. 
@@ -24,7 +36,7 @@ def get_jsonparsed_data(url):
     return json.loads(data)
 
 
-def get_EV_statement(ticker, period = 'annual'):
+def get_EV_statement(ticker, period='annual'):
     """
     Fetch EV statement, with details like total shares outstanding, from FMP.com
 
@@ -33,15 +45,12 @@ def get_EV_statement(ticker, period = 'annual'):
     returns:
         parsed EV statement
     """
-    if period == 'annual':
-        url = 'https://financialmodelingprep.com/api/v3/enterprise-value/{}'.format(ticker)
-    elif period == 'quarter':
-        url = 'https://financialmodelingprep.com/api/v3/enterprise-value/{}?period=quarter'.format(ticker)
+    url = get_api_url('enterprise-value', ticker, period)
     return get_jsonparsed_data(url)
 
 
 #! TODO: maybe combine these with argument flag for which statement, seems pretty redundant tbh
-def get_income_statement(ticker, period = 'annual'):
+def get_income_statement(ticker, period='annual'):
     """
     Fetch income statement.
 
@@ -52,17 +61,11 @@ def get_income_statement(ticker, period = 'annual'):
     returns:
         parsed company's income statement
     """
-    if period == 'annual':
-        url = 'https://financialmodelingprep.com/api/v3/financials/income-statement/{}'.format(ticker)
-    elif period == 'quarter':
-        url = 'https://financialmodelingprep.com/api/v3/financials/income-statement/{}?period=quarter'.format(ticker)
-    else:
-        raise ValueError("in get_income_statement: invalid period")     # may as well throw...
-
+    url = get_api_url('financials/income-statement', ticker, period)
     return get_jsonparsed_data(url)
 
 
-def get_cashflow_statement(ticker, period = 'annual'):
+def get_cashflow_statement(ticker, period='annual'):
     """
     Fetch cashflow statement.
 
@@ -73,13 +76,7 @@ def get_cashflow_statement(ticker, period = 'annual'):
     returns:
         parsed company's cashflow statement
     """
-    if period == 'annual':
-        url = 'https://financialmodelingprep.com/api/v3/financials/cash-flow-statement/{}'.format(ticker)
-    elif period == 'quarter':
-        url = 'https://financialmodelingprep.com/api/v3/financials/cash-flow-statement/{}?period=quarter'.format(ticker)
-    else:
-        raise ValueError("in get_cashflow_statement: invalid period")     # may as well throw...
-
+    url = get_api_url('financials/cash-flow-statement', ticker, period)
     return get_jsonparsed_data(url)
 
 
@@ -94,13 +91,7 @@ def get_balance_statement(ticker, period = 'annual'):
     returns:
         parsed company's balance sheet statement
     """
-    if period == 'annual':
-        url = 'https://financialmodelingprep.com/api/v3/financials/balance-sheet-statement/{}'.format(ticker)
-    elif period == 'quarter':
-        url = 'https://financialmodelingprep.com/api/v3/financials/balance-sheet-statement/{}?period=quarter'.format(ticker)
-    else:
-        raise ValueError("in get_balancesheet_statement: invalid period")     # may as well throw...
-
+    url = get_api_url('financials/balance-sheet-statement', ticker, period)
     return get_jsonparsed_data(url)
 
 
@@ -114,7 +105,8 @@ def get_stock_price(ticker):
     returns:
         {'symbol': ticker, 'price': price}
     """
-    url = 'https://financialmodelingprep.com/api/v3/stock/real-time-price/{}'.format(ticker)
+    url = 'https://financialmodelingprep.com/api/v3/stock/real-time-price/{}'.format(
+        ticker)
     return get_jsonparsed_data(url)
 
 
@@ -149,7 +141,8 @@ def get_historical_share_prices(ticker, dates):
     prices = {}
     for date in dates:
         date_start, date_end = date[0:8] + str(int(date[8:]) - 2), date
-        url = 'https://financialmodelingprep.com/api/v3/historical-price-full/{}?from={}&to={}'.format(ticker, date_start, date_end)
+        url = 'https://financialmodelingprep.com/api/v3/historical-price-full/{}?from={}&to={}'.format(
+            ticker, date_start, date_end)
         try:
             prices[date_end] = get_jsonparsed_data(url)['historical'][0]['close']
         except IndexError:

--- a/modeling/data.py
+++ b/modeling/data.py
@@ -1,15 +1,16 @@
-'''
+"""
 Utilizing financialmodelingprep.com for their free-endpoint API
 to gather company financials.
 
 NOTE: Some code taken directly from their documentation. See: https://financialmodelingprep.com/developer/docs/. 
-'''
+"""
 
 from urllib.request import urlopen
 import json
 
+
 def get_jsonparsed_data(url):
-    '''
+    """
     Fetch url, return parsed json. 
 
     args:
@@ -17,29 +18,31 @@ def get_jsonparsed_data(url):
     
     returns:
         parsed json
-    '''
+    """
     response = urlopen(url)
     data = response.read().decode('utf-8')
     return json.loads(data)
 
+
 def get_EV_statement(ticker, period = 'annual'):
-    '''
+    """
     Fetch EV statement, with details like total shares outstanding, from FMP.com
 
     args:
         ticker: company tickerr
     returns:
         parsed EV statement
-    '''
+    """
     if period == 'annual':
         url = 'https://financialmodelingprep.com/api/v3/enterprise-value/{}'.format(ticker)
     elif period == 'quarter':
         url = 'https://financialmodelingprep.com/api/v3/enterprise-value/{}?period=quarter'.format(ticker)
     return get_jsonparsed_data(url)
 
+
 #! TODO: maybe combine these with argument flag for which statement, seems pretty redundant tbh
 def get_income_statement(ticker, period = 'annual'):
-    '''
+    """
     Fetch income statement.
 
     args:
@@ -48,7 +51,7 @@ def get_income_statement(ticker, period = 'annual'):
 
     returns:
         parsed company's income statement
-    '''
+    """
     if period == 'annual':
         url = 'https://financialmodelingprep.com/api/v3/financials/income-statement/{}'.format(ticker)
     elif period == 'quarter':
@@ -60,7 +63,7 @@ def get_income_statement(ticker, period = 'annual'):
 
 
 def get_cashflow_statement(ticker, period = 'annual'):
-    '''
+    """
     Fetch cashflow statement.
 
     args:
@@ -69,7 +72,7 @@ def get_cashflow_statement(ticker, period = 'annual'):
 
     returns:
         parsed company's cashflow statement
-    '''
+    """
     if period == 'annual':
         url = 'https://financialmodelingprep.com/api/v3/financials/cash-flow-statement/{}'.format(ticker)
     elif period == 'quarter':
@@ -79,8 +82,9 @@ def get_cashflow_statement(ticker, period = 'annual'):
 
     return get_jsonparsed_data(url)
 
+
 def get_balance_statement(ticker, period = 'annual'):
-    '''
+    """
     Fetch balance sheet statement.
 
     args:
@@ -89,7 +93,7 @@ def get_balance_statement(ticker, period = 'annual'):
 
     returns:
         parsed company's balance sheet statement
-    '''
+    """
     if period == 'annual':
         url = 'https://financialmodelingprep.com/api/v3/financials/balance-sheet-statement/{}'.format(ticker)
     elif period == 'quarter':
@@ -99,8 +103,9 @@ def get_balance_statement(ticker, period = 'annual'):
 
     return get_jsonparsed_data(url)
 
+
 def get_stock_price(ticker):
-    '''
+    """
     Fetches the stock price for a ticker
 
     args:
@@ -108,12 +113,13 @@ def get_stock_price(ticker):
     
     returns:
         {'symbol': ticker, 'price': price}
-    '''
+    """
     url = 'https://financialmodelingprep.com/api/v3/stock/real-time-price/{}'.format(ticker)
     return get_jsonparsed_data(url)
 
+
 def get_batch_stock_prices(tickers):
-    '''
+    """
     Fetch the stock prices for a list of tickers.
 
     args:
@@ -121,15 +127,16 @@ def get_batch_stock_prices(tickers):
     
     returns:
         dict of {'ticker':  price}
-    '''
+    """
     prices = {}
     for ticker in tickers:
         prices[ticker] = get_stock_price(ticker)['price']
 
     return prices
 
+
 def get_historical_share_prices(ticker, dates):
-    '''
+    """
     Fetch the stock price for a ticker at the dates listed.
 
     args:
@@ -138,7 +145,7 @@ def get_historical_share_prices(ticker, dates):
 
     returns:
         {'date': price, ...}
-    '''
+    """
     prices = {}
     for date in dates:
         date_start, date_end = date[0:8] + str(int(date[8:]) - 2), date
@@ -154,8 +161,9 @@ def get_historical_share_prices(ticker, dates):
 
     return prices
 
+
 if __name__ == '__main__':
-    ''' quick test, to use run data.py directly '''
+    """ quick test, to use run data.py directly """
 
     ticker = 'AAPL'
     data = get_cashflow_statement(ticker)


### PR DESCRIPTION
This fixes https://github.com/halessi/DCF/issues/1 and adds an API-Key to the endpoint requests.
Without such API-Key the endpoint might just return
```
{"Error Message": "Invalid API KEY. Please retry or visit our documentation to create one FREE https://financialmodelingprep.com/developer/docs"}
```
Unfortunately the status code of the response is `200` so a `response.raise_for_status()` or similar doesn't work to validate if the returned data is valid.